### PR TITLE
Change user role after creation to match WooCommerce

### DIFF
--- a/LabelStoreMax/lib/resources/pages/account_register.dart
+++ b/LabelStoreMax/lib/resources/pages/account_register.dart
@@ -183,6 +183,11 @@ class _AccountRegistrationPageState extends NyState<AccountRegistrationPage> {
             username: username,
           ),
         );
+        
+        if (wpUserRegisterResponse?.data?.userToken != null) {
+          await WPJsonAPI.instance.api((request) => request.wpUserAddRole(wpUserRegisterResponse!.data!.userToken, role: "customer"));
+          await WPJsonAPI.instance.api((request) => request.wpUserRemoveRole(wpUserRegisterResponse!.data!.userToken, role: "subscriber"));
+        }
       } on UsernameTakenException catch (e) {
         showToastNotification(context,
             title: trans("Oops!"),


### PR DESCRIPTION
When a user creates an account through WooCommerce website, the new user has the role "customer".
Currently, the mobile app creates a "subscriber" user.
This PR add the new "customer" role to the user, and remove the "subscriber" role afterwards.