### PR TITLE
Dark theme fix for v6.2

### DIFF
--- a/LabelStoreMax/.env
+++ b/LabelStoreMax/.env
@@ -8,6 +8,10 @@ APP_URL="https://mywoocommercestore.com"
 ASSET_PATH_PUBLIC="public/assets/"
 ASSET_PATH_IMAGES="public/assets/images"
 TIMEZONE="UTC"
+
+LIGHT_THEME_ID="default_light_theme"
+DARK_THEME_ID="default_dark_theme"
+
 # *<! ------ Language  ------!>*
 
 DEFAULT_LOCALE=null


### PR DESCRIPTION
I maybe missed something, but I don't see where the following env variables are set:
- LIGHT_THEME_ID
- DARK_THEME_ID

This change seems to work on my build. Please correct me if I missed something.

Should fix  #49